### PR TITLE
Should only lowercase first character

### DIFF
--- a/Source/CottonObject.m
+++ b/Source/CottonObject.m
@@ -392,8 +392,8 @@
 
     // turn the first character into a lower case letter
     NSString* character = [key substringToIndex:1];
-    key = [key stringByReplacingOccurrencesOfString:character
-                                         withString:character.lowercaseString];
+    key = [key stringByReplacingCharactersInRange:NSMakeRange(0, 1)
+                                       withString:character.lowercaseString];
 
     // insert or remove
     [self setObject:object forKey:key];


### PR DESCRIPTION
In `setObject:forSetter` only the first character of the property should be lowercased or else all characters in the string are lowercased...which makes for some weirdness. Currently `setDanceDuration ` would transform into danceduration instead of danceDuration