### PR TITLE
Assert & return methods & numberFor cleanup

### DIFF
--- a/Source/CO_Assert.h
+++ b/Source/CO_Assert.h
@@ -14,6 +14,9 @@
     #endif
     #define CO_ALog(...) NSLog(@"%s %@", __PRETTY_FUNCTION__, [NSString stringWithFormat:__VA_ARGS__])
 #endif
+
 #define CO_Assert(condition, ...) do { if (!(condition)) { CO_ALog(__VA_ARGS__); }} while(0)
+#define CO_AssertReturn(condition, ...) do { if (!(condition)) { CO_ALog(__VA_ARGS__); return; }} while(0)
+#define CO_AssertReturnNil(condition, ...) do { if (!(condition)) { CO_ALog(__VA_ARGS__); return nil; }} while(0)
 
 #endif

--- a/Source/CottonObject.m
+++ b/Source/CottonObject.m
@@ -435,12 +435,12 @@
 {
     // key must be at least a 4 character string
     NSString* key = NSStringFromSelector(setter);
-    CO_Assert(key.length >= 4, @"Setter '%@' must be at least 4 characters long", key);
+    CO_AssertReturn(key.length >= 4, @"Setter '%@' must be at least 4 characters long", key);
 
     // validate it for the form setBlah:
     NSArray* tokens = [key componentsSeparatedByString:@":"];
-    CO_Assert(tokens.count == 2, @"Setter '%@' can only have one argument", key);
-    CO_Assert([key hasPrefix:@"set"], @"Setter '%@' must start with 'set'", key);
+    CO_AssertReturn(tokens.count == 2, @"Setter '%@' can only have one argument", key);
+    CO_AssertReturn([key hasPrefix:@"set"], @"Setter '%@' must start with 'set'", key);
 
     // strip the set and : from the name
     NSRange range = NSMakeRange(3, key.length - 4);
@@ -463,7 +463,7 @@
 {
     // this only supports making arrays of CottonObject subclasses
     // this is what allows parent-child CottonObject classes to be instanced
-    CO_Assert([aClass isMemberOfClass:CottonObject.class] == NO,
+    CO_AssertReturnNil([aClass isMemberOfClass:CottonObject.class] == NO,
               @"Class '%@' must be a subclass of CottonObject",
               NSStringFromClass(aClass));
 
@@ -491,7 +491,7 @@
 - (NSArray*) arrayWithClassNamed:(NSString*)objectClassName forKey:(NSString*)key
 {
     Class class = NSClassFromString(objectClassName);
-    CO_Assert(class, @"The class you are trying to instantiate does not exist: %@", objectClassName);
+    CO_AssertReturnNil(class, @"The class you are trying to instantiate does not exist: %@", objectClassName);
     return [self arrayWithClass:class forKey:key];
 }
 
@@ -530,7 +530,7 @@
 - (id) objectWithClassNamed:(NSString*)objectClassName forKey:(NSString*)key fromBlock:(id(^)())fromBlock
 {
     Class class = NSClassFromString(objectClassName);
-    CO_Assert(class, @"The class you are trying to instantiate does not exist: %@", objectClassName);
+    CO_AssertReturnNil(class, @"The class you are trying to instantiate does not exist: %@", objectClassName);
     return [self objectWithClass:class forKey:key fromBlock:fromBlock];
 }
 
@@ -546,7 +546,7 @@
     // nothing to do if already the desired class
     if (isDesiredClass) { return value; };
     
-    CO_Assert(fromBlock, @"You must implement a non-nil fromBlock to create the instance of the object.");
+    CO_AssertReturnNil(fromBlock, @"You must implement a non-nil fromBlock to create the instance of the object.");
     
     // check if the block was able to create a valid object
     id object = fromBlock();
@@ -570,7 +570,7 @@
 - (id) objectWithClassNamed:(NSString*)objectClassName forKey:(NSString*)key
 {
     Class class = NSClassFromString(objectClassName);
-    CO_Assert(class, @"The class you are trying to instantiate does not exist: %@", objectClassName);
+    CO_AssertReturnNil(class, @"The class you are trying to instantiate does not exist: %@", objectClassName);
     return [self objectWithClass:class forKey:key];
 }
 
@@ -592,10 +592,10 @@
     
     // and nothing to do if it is not a dictionary
     BOOL isDictionary = ([value isKindOfClass:NSDictionary.class]);
-    CO_Assert(isDictionary, @"Value for key '%@' is not an NSDictionary", key);
+    CO_AssertReturnNil(isDictionary, @"Value for key '%@' is not an NSDictionary", key);
 
     // ensure we always create an instance of CottonObject
-    CO_Assert([objectClass isSubclassOfClass:CottonObject.class], @"Object you are creating must be a subclass of `CottonObject`");
+    CO_AssertReturnNil([objectClass isSubclassOfClass:CottonObject.class], @"Object you are creating must be a subclass of `CottonObject`");
 
     // make an instance of the class with the confirmed dictionary
     id object = [[objectClass alloc] initWithDictionary:value];

--- a/Source/CottonObject.m
+++ b/Source/CottonObject.m
@@ -173,32 +173,28 @@
 
 - (BOOL) boolForKey:(NSString*)key
 {
-    NSNumber* boolNumber = [self objectWithClass:NSNumber.class forKey:key];
-    return boolNumber.boolValue;
+    return [self numberForKey:key].boolValue;
 }
 
 //------------------------------------------------------------------------------
 
 - (float) floatForKey:(NSString*)key
 {
-    NSNumber* floatNumber = [self objectWithClass:NSNumber.class forKey:key];
-    return floatNumber.floatValue;
+    return [self numberForKey:key].floatValue;
 }
 
 //------------------------------------------------------------------------------
 
 - (double) doubleForKey:(NSString*)key
 {
-    NSNumber* doubleNumber = [self objectWithClass:NSNumber.class forKey:key];
-    return doubleNumber.doubleValue;
+    return [self numberForKey:key].doubleValue;
 }
 
 //------------------------------------------------------------------------------
 
 - (NSInteger) integerForKey:(NSString*)key
 {
-    NSNumber* integerNumber = [self numberForKey:key];
-    return integerNumber.integerValue;
+    return [self numberForKey:key].integerValue;
 }
 
 //------------------------------------------------------------------------------
@@ -206,21 +202,18 @@
 - (NSNumber*) numberForKey:(NSString*)key
 {
     // already a number
-    NSNumber* number = [self objectWithClass:NSNumber.class forKey:key];
-    if (number != nil)
+    id value = self.dictionary[key];
+    if ([value isKindOfClass:NSNumber.class])
     {
-        return number;
+        return value;
     }
     
     // number from a string
-    NSString* stringValue = [self objectWithClass:NSString.class forKey:key];
-    if (stringValue)
-    {
-        NSNumberFormatter* formatter = [[NSNumberFormatter alloc] init];
-        number = [formatter numberFromString:stringValue];
-    }
-        
-    // if this far then not a number
+    NSNumberFormatter* formatter = [[NSNumberFormatter alloc] init];
+    NSNumber* number = [formatter numberFromString:(NSString *)value];
+
+    [self setObject:number forKey:key];
+
     return number;
 }
 
@@ -590,9 +583,11 @@
     // nothing to do if already the desired class
     if (isDesiredClass) { return value; };
     
-    // and nothing to do if it is not a dictionary
+    // if it is not a dictionary, return value
     BOOL isDictionary = ([value isKindOfClass:NSDictionary.class]);
-    CO_AssertReturnNil(isDictionary, @"Value for key '%@' is not an NSDictionary", key);
+    if (!isDictionary) {
+        return value;
+    }
 
     // ensure we always create an instance of CottonObject
     CO_AssertReturnNil([objectClass isSubclassOfClass:CottonObject.class], @"Object you are creating must be a subclass of `CottonObject`");


### PR DESCRIPTION
Issues:
1. numberForKey was crashing because the JSON bundle was returning an NSTaggedString and the code was executing past the assertions in the objectWithClass method. Instead, the numberForKey method was looking for a nil return that it never received.
2. Most number methods were using `objectWithClass` but should just be derivative of the `numberForKey` method
3. Ensured `objectWithClass` could be used for classes other than just `NSDictionary` since it seems that's how it was being used internally and within other projects
